### PR TITLE
Update instructions for axios 0.19.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,10 +14,16 @@ npm install axios-jsonp
 let axios = require('axios');
 let jsonpAdapter = require('axios-jsonp');
 
-axios({
+const instance = axios.create()
+
+instance.interceptors.request.use(config => ({
+  ...config,
+  callbackParamName: 'c' // optional, 'callback' by default
+}), err => Promise.reject(err))
+
+instance.get({
     url: '/jsonp',
     adapter: jsonpAdapter,
-    callbackParamName: 'c' // optional, 'callback' by default
 }).then((res) => {
 
 });


### PR DESCRIPTION
Passing `callbackParamName` via main invocation wasn't working for me, but via an interceptor worked!

Axios version: 0.19.0