### PR TITLE
Reject the promise if loading the script fails

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,6 +65,7 @@ module.exports = function jsonpAdapter(config) {
                 script = null;
             }
         };
+        script.onerror = reject;
 
         if (config.cancelToken) {
             config.cancelToken.promise.then(function(cancel) {


### PR DESCRIPTION
Hi,

Thank you for this. 

I noticed the promise isn't rejected when the script fails to load (e.g. a 404). This should fix that.