### PR TITLE
simplify params caculation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,14 +15,6 @@ module.exports = function jsonpAdapter(config) {
         var script = document.createElement('script');
         var src = config.url;
 
-        if (config.params) {
-            var params = buildParams(config.params);
-
-            if (params) {
-                src += (src.indexOf('?') >= 0 ? '&' : '?') + params;
-            }
-        }
-
         script.async = true;
 
         function remove() {
@@ -56,13 +48,10 @@ module.exports = function jsonpAdapter(config) {
             resolve(response);
         };
 
-        var additionalParams = {
-            _: (new Date().getTime())
-        };
-        
-        additionalParams[config.callbackParamName || 'callback'] = jsonp;
-
-        src += (src.indexOf('?') >= 0 ? '&' : '?') + buildParams(additionalParams);
+        config.params = config.params || {};
+        config.params._ = Date.now();
+        config.params[config.callbackParamName || 'callback'] = jsonp;
+        src += (src.indexOf('?') >= 0 ? '&' : '?') + buildParams(config.params);
 
         script.onload = script.onreadystatechange = function() {
             if (!script.readyState || /loaded|complete/.test(script.readyState)) {


### PR DESCRIPTION
This pr simplifies params caculation, and callback param position can be adjustable. for example, there's a api that callback must be the first param, we can write code in this way:
```js
axios({
  url: 'http://blabla.com/a_api_that_callback_must_be_the_first_param',
  adapter: jsonp,
  params: { callback: '', foo: 1, bar: 2 }
})
```